### PR TITLE
mock event example in post_status_spec

### DIFF
--- a/spec/views/post_status_spec.js
+++ b/spec/views/post_status_spec.js
@@ -1,26 +1,50 @@
 require('/js/views/post_status.js');
 
 describe("Monologue.View.PostStatus", function() {
-  var view, $el, collection;
+  var view, $el, collection, input, mockEvent;
 
   beforeEach(function() {
-    $el = $("<form><textarea>See, it's not so hard!</textarea></form>");
-    collection = new (Backbone.Collection.extend({url: '/mock'}));
-    // prevent collection from trying to sync with the server
-    spyOn(collection, 'create');
+   $el = $("<form><textarea>See, it's not so hard!</textarea></form>");
+   collection = new (Backbone.Collection.extend({url: '/mock'}));
+   // prevent collection from trying to sync with the server
+   spyOn(collection, 'create');
 
-    view = new Monologue.View.PostStatus({el: $el, collection: collection});
+   view = new Monologue.View.PostStatus({el: $el, collection: collection});
+  });
+
+  describe("events", function() {
+    it("binds 'submit' to 'submit'", function() {
+      expect(view.events['submit']).toBe("submit");
+    });
   });
 
   describe("submitting the form", function() {
-    it("creates status when submitting form", function() {
-      $el.trigger('submit');
+    beforeEach(function() {
+      input = document.createElement('input');
+      input.value = "See, it's not so hard!";
+
+      mockEvent = {
+        preventDefault: function() {},
+        currentTarget: input
+      }
+
+      spyOn(mockEvent, 'preventDefault');
+    });
+
+    it("delegates create to collection", function() {
+      view.submit(mockEvent);
       expect(collection.create).toHaveBeenCalledWith({text: "See, it's not so hard!"});
     });
 
-    it("clears the textarea", function() {
-      $el.trigger('submit');
-      expect($el.find('textarea').val()).toEqual('');
+    it("prevents default event actions", function() {
+      view.submit(mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
     });
+
+   it("clears the textarea", function() {
+     $el.trigger('submit');
+     expect($el.find('textarea').val()).toEqual('');
+   });
   });
 });


### PR DESCRIPTION
An example of testing functions in Backbone Views without a real jQuery object. Instead of creating an $el and passing it to the the view, you can do two things:
#1 - test that your events hash is constructed properly
#2 - send a mockEvent with a currentTarget attribute to the bound function that has what you need.

Actually using a jQuery object to test the clearing of the field is interesting - what I've done is set up a fixture that wraps the html I want in a <div id="test"> tag, then use jQuery to find that element after my code executes to assert that it is empty. I'm not sure if that is better or worse than the current setup you have.

This is pretty basic - I think the next step would be to create a spec helper function that can generate these mockEvents with targets easily so you don't have so much setup in your beforeEach.
